### PR TITLE
Doesn't work in versions higher than 52

### DIFF
--- a/BoundWithBox.sketchplugin/Contents/Sketch/manifest.json
+++ b/BoundWithBox.sketchplugin/Contents/Sketch/manifest.json
@@ -16,7 +16,7 @@
 		"title" : "Bound with Box"
 	},
 	"identifier"  : "com.example.sketch.sketch-bound-with-box",
-	"version"     : 1.5.1,
+	"version"     : 1.6,
 	"description" : "This plugin takes the selected layer(s) and draws a rectangle around them.",
 	"authorEmail" : "",
 	"name"        : "Sketch Bound with Box"

--- a/BoundWithBox.sketchplugin/Contents/Sketch/manifest.json
+++ b/BoundWithBox.sketchplugin/Contents/Sketch/manifest.json
@@ -16,7 +16,7 @@
 		"title" : "Bound with Box"
 	},
 	"identifier"  : "com.example.sketch.sketch-bound-with-box",
-	"version"     : 1.5,
+	"version"     : 1.5.1,
 	"description" : "This plugin takes the selected layer(s) and draws a rectangle around them.",
 	"authorEmail" : "",
 	"name"        : "Sketch Bound with Box"

--- a/BoundWithBox.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/BoundWithBox.sketchplugin/Contents/Sketch/script.cocoascript
@@ -123,12 +123,8 @@ var onRun = function(context) {
 			posY = posY - (paddingHeight / 2);
 		}
 
-		// Create rectangle
-		var rect   = MSRectangleShape.alloc().init();
-		rect.frame = MSRect.rectWithRect(NSMakeRect(posX, posY, width, height));
-
 		// Add default styling
-		var shapeGroup = MSShapeGroup.shapeWithPath(rect);
+		var shapeGroup = MSShapeGroup.shapeWithRect(NSMakeRect(posX, posY, width, height));
 		shapeGroup.style().addStylePartOfType(0);
 
 		// Add to the container


### PR DESCRIPTION
Sketch team deprecated shapeWithPath. I made a pull request to fix it and now works on Sketch 52.5.

This was the error:
`TypeError: MSShapeGroup.shapeWithPath is not a function.`